### PR TITLE
Added in code to pull in posts

### DIFF
--- a/_posts/2015-05-23-vancouver-intl-node-day-2015.md
+++ b/_posts/2015-05-23-vancouver-intl-node-day-2015.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title: NodeSchool Vancouver Intl. Node Day
+headline: International Node Day May 23rd, 2015
+---
+
+### Dates
+
+23rd May 2015
+
+The event will run from noon until about 4:00pm.
+
+Feel free to come a little early and help set up.
+
+### Location
+
+1122 Mainland St near Yaletown Canada Line station.
+
+Buzz **#460** for entry and take the elevator to the 4th floor. Follow the signs to "Zillow".
+
+### What to prepare before attending
+
+[Speak, friend, and enter!](https://gist.github.com/gyaresu/1848acc320e4c441d995)
+
+### Code of Conduct
+
+Code of Conduct for Nodeschool Vancouver: [policy](../code-of-conduct)
+
+No photography without an individuals permission: [Blog post on why.](https://adainitiative.org/2013/07/another-way-to-attract-women-to-conferences-photography-policies/)
+
+Google Maps link: [1122 Mainland St](https://www.google.ca/maps/place/1122+Mainland+St,+Vancouver,+BC+V6B+5L1/@49.2752371,-123.1208496,17z/data=!3m1!4b1!4m2!3m1!1s0x548673d6fe9b862f:0x46c6e2ce937f8b89?hl=en)
+
+### Organizers
+
+* Luke Vivier:    [@LukeVivier](https://twitter.com/LukeVivier)
+* Brock Whitten:  [@sintaxi](https://twitter.com/sintaxi)
+* Gareth:         [@gyaresu](http://twitter.com/gyaresu)

--- a/index.html
+++ b/index.html
@@ -13,14 +13,19 @@ title: NodeSchool Vancouver
                 <div class="icons-inline">
                     <a href="http://www.meetup.com/{{site.meetup}}/"><img class="icon" src="{{site.url}}/img/meetup.png"></a>
                 </div>
-                <p>NodeSchool Vancouver meets every so often. The meetings are working sessions, so <strong>please bring a laptop</strong>. <a href="/mentors">Mentors</a> will be available to help if you're just getting started with Node, or even if you're a seasoned veteran and want to learn more.</p>
+                <p>NodeSchool Vancouver is part of the broader Node Brigade community. We are likely moving off Meetup soon, so stay tuned.</p>
+                    
+                    <p>The NodeSchool meetings are working sessions, so <strong>please bring a laptop</strong>. <a href="/mentors">Mentors</a> will be available to help if you're just getting started with Node, or even if you're a seasoned veteran and want to learn more.</p>
 
-                <h3>Upcoming Event</h3>
+                <h3>Upcoming Events</h3>
+                <!-- Could be replaced with posts with future dates -->
                 <div class="next-event">No upcoming event scheduled, please check back later!</div>
 
-                <h3>Event Notes</h3>
+                <h3>News & Past Events</h3>
                 <ul>
-                    <li>Write up International Day / NodeSchool Vancouver #1 here</li>
+                    {% for post in site.posts %}
+  <li><article><a href="{{ site.url }}{{ post.url }}">{{ post.title }} <span class="entry-date"><time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %d, %Y" }}</time></span></a></article></li>
+{% endfor %}
                 </ul>
             </div>
             <div class="additional-info">
@@ -39,10 +44,9 @@ title: NodeSchool Vancouver
                         </a>
                     </div>
                     <div class="extended">
-                        <a href="https://gitter.im/nodeschool/yvr">
-                            <!-- should get changed to vancouver, gitter room needs editing -->
+                        <a href="https://gitter.im/nodeschool/{{site.repo}}">
                             <div>
-                                <img class="gitter icon" src="img/gitter-icon.png">
+                                <img class="gitter icon" src="{{site.url}}/img/gitter-icon.png">
                             </div>
                             <div>
                                 Gitter Chat
@@ -63,7 +67,7 @@ title: NodeSchool Vancouver
 
                 <p>Someone will write info on who the main organizers are</p>
 
-                <p>Want to help? Add your name to our <a href="https://github.com/nodeschool/{{site.repo}}/blob/master/mentors.md">mentors list</a>! (Please let us know if you need access to the <a href="https://github.com/orgs/nodeschool/teams/{{site.repo}}"> NodeSchool team</a>.)</p>
+                <p>Want to help? Add your name to our <a href="https://github.com/nodeschool/{{site.repo}}/blob/gh-pages/mentors.md">mentors list</a>! (Please let us know if you need access to the <a href="https://github.com/orgs/nodeschool/teams/{{site.repo}}"> NodeSchool team</a>.)</p>
 
                 <p>Want to sponsor? We're very grateful for our sponsors, please let us know if you or your company would like to help!</p>
             </div>
@@ -95,7 +99,7 @@ title: NodeSchool Vancouver
                 <p>If you're stuck on anything NodeSchool, or Node in general, please feel free to <a href="#contact">contact us</a>.</p>
 
                 <ul>
-                    <li>Austin NodeSchool GitHub site: <a href="https://github.com/nodeschool/austin">https://github.com/nodeschool/austin</a></li>
+                    <li>{{site.name}} GitHub site: <a href="https://github.com/nodeschool/{{site.repo}}">https://github.com/nodeschool/{{site.repo}}</a></li>
                     <li>Global NodeSchool GitHub issues (contains a long history of questions and answers about NodeSchool): <a href="https://github.com/nodeschool/discussions/issues">https://github.com/nodeschool/discussions/issues</a></li>
                     <li>NodeUp Podcast discussing NodeSchool: <a href="http://nodeup.com/fiftyfive">http://nodeup.com/fiftyfive</a></li>
                     <li>Teach Your Way to Becoming a Better Programmer (via NodeSchool): <a href="https://medium.com/social-tables-tech/teach-your-way-to-becoming-a-better-programmer-135c6aca5968">https://medium.com/social-tables-tech/teach-your-way-to-becoming-a-better-programmer-135c6aca5968</a></li>


### PR DESCRIPTION
Removed all of the Austin-isms other than the hex logo.

Added a note about likely moving off Meetup, although I've left the meetup pulling script in.

Can now easily add posts which will be displayed on the front page under News & Past Events, and created the first one,
