### PR TITLE
Update comms info, event info on site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ software skills. Individuals are encouraged to do the
 [workshoppers](http://nodeschool.io/) on their own or at one of the
 NodeSchool events around the world. The workshopper tutorials are used
 as the course curriculum, while mentors are here to help attendees
-work through challenges.
-
-- [Website](http://nodeschool.io/vancouver/)
-- [Mailing List (low traffic)](mailto:vancouver.nodeschool@librelist.com)
-- [Unsubscribe](vancouver.nodeschool-unsubscribe@librelist.com)
+work through challenges. Learn more [here](http://nodeschool.io/vancouver/).
 
 ## Get in touch
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ response time for an organizer to respond.
 ### Tier 1: Max response time within 1 day, real-time on workshop days
 
 - [twitter](https://twitter.com/nodeschoolyvr): tweet [@nodeschoolyvr](https://twitter.com/nodeschoolyvr) for general chat
-- [slack](https://yvrdev.slack.com): for general chat, planning meetups, and
-questions about workshops if you're challenging yourself at home. Signup [here](https://yvrdev.herokuapp.com/) and DM /@manil for an invite to our
-channel
+- [slack](https://yvrdev.slack.com): (new starting Dec 13 2017) for general chat, planning meetups, and
+questions about workshops if you're challenging yourself at home. Go to the YVRDev slack [here](https://yvrdev.herokuapp.com/) and join the #nodeschool-yvr channel
 - [github issues](https://github.com/nodeschool/vancouver/issues/): for planning
 
 ### Tier 2: Max response time of 3 days
@@ -36,7 +35,7 @@ channel
 ## Want to attend? ✨
 
 Check out our [scheduled events](https://www.meetup.com/nodeschool-vancouver) on
-meetup.com. Feel free to come a 15 minutes early and help set up!
+meetup.com. Feel free to come 15 minutes early and help set up!
 
 Workshops from before Nov 2017 are archived
 [here](https://ti.to/nodeschool-vancouver).
@@ -65,7 +64,7 @@ on what it's like being a mentor prior to signing up!
 
 If you've come to a few NodeSchool events, we encourage you to mentor! :tada:
 
-### Code of Conduct 
+### Code of Conduct
 
 - [Code of Conduct for Nodeschool Vancouver](code-of-conduct.md)
 - [No photography without an individual's permission](https://adainitiative.org/2013/07/another-way-to-attract-women-to-conferences-photography-policies/)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ work through challenges.
 - [Mailing List (low traffic)](mailto:vancouver.nodeschool@librelist.com)
 - [Unsubscribe](vancouver.nodeschool-unsubscribe@librelist.com)
 
+## Get in touch
+
+Every community needs a reliable way to communicate. To make it easier, we have
+a few ways for everyone to speak with each other. We've also included a max
+response time for an organizer to respond.
+
+### Tier 1: Max response time within 1 day, real-time on workshop days
+
+- [twitter](https://twitter.com/nodeschoolyvr): tweet [@nodeschoolyvr](https://twitter.com/nodeschoolyvr) for general chat
+- [slack](https://yvrdev.slack.com): for general chat, planning meetups, and
+questions about workshops if you're challenging yourself at home. DM /@manil for
+an invite to our channel
+- [github issues](https://github.com/nodeschool/vancouver/issues/): for planning
+
+### Tier 2: Max response time of 3 days
+
+- [meetup](https://www.meetup.com/nodeschool-vancouver/): general info
+
+### Tier 3: Max response time of 7 days, phasing out by March 2018
+
+- [gitter](https://gitter.im/nodeschool/vancouver): general chat
+
 ## Want to attend?
 
 Check out our [events page](https://ti.to/nodeschool-vancouver). Feel

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 # NodeSchool Vancouver [![Join the chat at https://gitter.im/nodeschool/vancouver](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodeschool/vancouver?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-_**We organise all of our events in the [Issues](nodeschool/vancouver/issues) section here on GitHub**_
+_**All of our scheduled events are on
+[meetup.com](https://www.meetup.com/nodeschool-vancouver)**_
 
 NodeSchool is a series of open source workshops that teach web
 software skills. Individuals are encouraged to do the
@@ -30,7 +31,7 @@ an invite to our channel
 
 ### Tier 2: Max response time of 3 days
 
-- [meetup](https://www.meetup.com/nodeschool-vancouver/): general info
+- [meetup.com](https://www.meetup.com/nodeschool-vancouver): general info
 
 ### Tier 3: Max response time of 7 days, phasing out by March 2018
 
@@ -38,8 +39,11 @@ an invite to our channel
 
 ## Want to attend?
 
-Check out our [events page](https://ti.to/nodeschool-vancouver). Feel
-free to come a little early and help set up!
+Check out our [scheduled events](https://www.meetup.com/nodeschool-vancouver) on
+meetup.com. Feel free to come a 15 minutes early and help set up!
+
+Workshops from before Nov 2017 are archived
+[here](https://ti.to/nodeschool-vancouver).
 
 ### Want to mentor or help organize?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# NodeSchool Vancouver [![Join the chat at https://gitter.im/nodeschool/vancouver](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodeschool/vancouver?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# NodeSchool Vancouver 🇨🇦 [![Join the chat at https://gitter.im/nodeschool/vancouver](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodeschool/vancouver?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 _**All of our scheduled events are on
 [meetup.com](https://www.meetup.com/nodeschool-vancouver)**_
@@ -11,7 +11,7 @@ NodeSchool events around the world. The workshopper tutorials are used
 as the course curriculum, while mentors are here to help attendees
 work through challenges. Learn more [here](http://nodeschool.io/vancouver/).
 
-## Get in touch
+## Get in touch ⚡️
 
 Every community needs a reliable way to communicate. To make it easier, we have
 a few ways for everyone to speak with each other. We've also included a max
@@ -33,7 +33,7 @@ channel
 
 - [gitter](https://gitter.im/nodeschool/vancouver): general chat
 
-## Want to attend?
+## Want to attend? ✨
 
 Check out our [scheduled events](https://www.meetup.com/nodeschool-vancouver) on
 meetup.com. Feel free to come a 15 minutes early and help set up!
@@ -41,7 +41,7 @@ meetup.com. Feel free to come a 15 minutes early and help set up!
 Workshops from before Nov 2017 are archived
 [here](https://ti.to/nodeschool-vancouver).
 
-### Want to mentor or help organize?
+### Want to mentor or help organize? 💛
 
 If you are interested in mentoring, please make a
 [Pull Request](https://github.com/nodeschool/vancouver/pulls) to add
@@ -65,7 +65,7 @@ on what it's like being a mentor prior to signing up!
 
 If you've come to a few NodeSchool events, we encourage you to mentor! :tada:
 
-### Code of Conduct
+### Code of Conduct 
 
 - [Code of Conduct for Nodeschool Vancouver](code-of-conduct.md)
 - [No photography without an individual's permission](https://adainitiative.org/2013/07/another-way-to-attract-women-to-conferences-photography-policies/)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ response time for an organizer to respond.
 
 - [twitter](https://twitter.com/nodeschoolyvr): tweet [@nodeschoolyvr](https://twitter.com/nodeschoolyvr) for general chat
 - [slack](https://yvrdev.slack.com): for general chat, planning meetups, and
-questions about workshops if you're challenging yourself at home. DM /@manil for
-an invite to our channel
+questions about workshops if you're challenging yourself at home. Signup [here](https://yvrdev.herokuapp.com/) and DM /@manil for an invite to our
+channel
 - [github issues](https://github.com/nodeschool/vancouver/issues/): for planning
 
 ### Tier 2: Max response time of 3 days

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,11 +12,28 @@
       <h1>Welcome to<br>NodeSchool Vancouver</h1>
     </header>
     <main>
-      <p>NodeSchool Vancouver is a free monthly meetup organized and run by volunteers where you can learn the basics of JavaScript and Node.JS through informal self-guided workshops, with experienced mentors to provide help if you need it.</p>
+      <p>
+        NodeSchool Vancouver is a free monthly meetup for learning code!
+        It's organized and run by volunteers sofware developers.
+        Here you can learn the basics of JavaScript and Node.js in a supportive
+        environment.
+        Experienced mentors guide you through workshops, and small projects.
+        We answer your questions, and give help if you want it.
+      </p>
       <br>
-      <p>Everyone is welcome! Even if this is your first experience programming the only thing you need to start is a laptop and a sense of adventure! There's no barrier to learning to code.</p>
+      <p>
+        Everyone is welcome!
+        Even if this is your first experience programming.
+        The only thing you need to start is a laptop and a sense of adventure!
+        There's no barrier to learning to code.
+      </p>
       <br>
-      <p>Interested? Then stay in touch with us through Gitter, Github, or follow us on Twitter for the latest news about our upcoming events! </p>
+      <p>
+        <a href=https://www.meetup.com/nodeschool-vancouver>Join us</a> for the
+        latest on upcoming events! And jump into the conversations through the
+        channels below.
+      </p>
+      <br>
       <div class="contact">
         <a href="https://github.com/nodeschool/vancouver">
           <i class="fa fa-github" aria-hidden="true"></i>

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       <div class="contact">
         <a href="https://twitter.com/nodeschoolyvr">
           <i class="fa fa-twitter" aria-hidden="true"></i>
-          tweet questions @nodeschoolyvr
+          tweet @nodeschoolyvr
         </a>
         <br>
         <br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,8 @@
     </header>
     <main>
       <p>
-        NodeSchool Vancouver is a free monthly meetup for learning code!
+        <h4>Hello!</h4>
+        NodeSchool Vancouver is a free monthly meetup for learning code.
         It's organized and run by volunteers sofware developers.
         Here you can learn the basics of JavaScript and Node.js in a supportive
         environment.
@@ -22,16 +23,17 @@
       </p>
       <br>
       <p>
-        Everyone is welcome!
+        <h4>Everyone is welcome 💛</h4>
         Even if this is your first experience programming.
         The only thing you need to start is a laptop and a sense of adventure!
         There's no barrier to learning to code.
       </p>
       <br>
       <p>
-        <a href=https://www.meetup.com/nodeschool-vancouver>Join us</a> for the
-        latest on upcoming events! And jump into the conversations through the
-        channels below.
+        <h4>All aboard 🚅</h4>
+        <a href='https://www.meetup.com/nodeschool-vancouver'>Join us</a> for
+        the latest on upcoming events! And jump into the conversations through
+        the channels below.
       </p>
       <br>
       <div class="contact">
@@ -55,8 +57,9 @@
 
       <br>
       <div class="events">
-        <a href="https://ti.to/nodeschool-vancouver/">
-          <i class="fa fa-calendar" aria-hidden="true"></i> See past and upcoming events
+        <a href='https://www.meetup.com/nodeschool-vancouver'>
+          <i class="fa fa-calendar" aria-hidden="true"></i>
+          see upcoming events
         </a>
       </div>
 
@@ -69,7 +72,9 @@
 
     <div class="sm">
       <article>
+        <br>
         <h2>About NodeSchool</h2>
+        <br>
 
         <p>NodeSchool is an open source project run by volunteers with two goals: <b>creating a high quality programming curriculum</b> and to <b>host community learning events</b>. Our curriculum is focused around the "workshopper" format which was first created by
         <a href="http://substack.net/">Substack of the Internet</a> in Summer 2013 when he wrote the

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,20 +35,25 @@
       </p>
       <br>
       <div class="contact">
-        <a href="https://github.com/nodeschool/vancouver">
-          <i class="fa fa-github" aria-hidden="true"></i>
-          GitHub
-        </a>
-        <a href="https://gitter.im/nodeschool/vancouver">
-          <i class="fa fa-comments-o" aria-hidden="true"></i>
-          Gitter Chat
-        </a>
         <a href="https://twitter.com/nodeschoolyvr">
           <i class="fa fa-twitter" aria-hidden="true"></i>
-          Twitter
+          tweet questions @nodeschoolyvr
+        </a>
+        <br>
+        <br>
+        <a href="https://yvrdev.herokuapp.com/">
+          <i class="fa fa-slack" aria-hidden="true"></i>
+          chat on #nodeschool-yvr channel on yvrdev slack
+        </a>
+        <br>
+        <br>
+        <a href="https://github.com/nodeschool/vancouver">
+          <i class="fa fa-github" aria-hidden="true"></i>
+          help out on github
         </a>
       </div>
 
+      <br>
       <div class="events">
         <a href="https://ti.to/nodeschool-vancouver/">
           <i class="fa fa-calendar" aria-hidden="true"></i> See past and upcoming events

--- a/docs/main.css
+++ b/docs/main.css
@@ -8,11 +8,11 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'AvenirNext-Medium', 'Trebuchet MS', sans-serif;
-  font-weight: 'medium';
-  font-size: 26pt;
+  font-size: 22pt;
   color: #555;
 }
 header, main, article, footer {
+  text-align: center;
   margin: 0 auto;
   padding: 1em 0;
   max-width: 1024px;


### PR DESCRIPTION
Fixes https://github.com/nodeschool/vancouver/issues/64

1. Update our README (https://github.com/nodeschool/vancouver) to show the response time and intended purpose (such as Github being for planning and meta issues) of each comm channel.
2. Update the meetup group with the same (not in diff :p )
3. Update the site (https://nodeschool.io/vancouver/) with the same.
4. While we're at it, update the site and README with a link to the new meetup group.
5. Make a few edits (see commits).

Site before:
![screen shot 2017-12-09 at 02 42 35](https://user-images.githubusercontent.com/10335475/33794954-aec4e402-dc8a-11e7-85e4-954eb66eb75f.png)

Site after:
![screen shot 2017-12-09 at 02 42 27](https://user-images.githubusercontent.com/10335475/33794953-a6d1c0a8-dc8a-11e7-9dd3-4bd95df3ae05.png)