### PR TITLE
Add new organizer notes

### DIFF
--- a/ADMIN.md
+++ b/ADMIN.md
@@ -1,0 +1,6 @@
+# Adding an organizer
+
+Adding a new person to the organizers team? That's great! Here's a list of some places that should be updated to include the new organizer.
+
+- [email aliases](https://github.com/nodeschool/email/blob/master/nodeschool.io/aliases.json) 
+- [chapter metadata](https://github.com/nodeschool/nodeschool.github.io/blob/source/chapters/vancouver.json)

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -2,5 +2,5 @@
 
 Adding a new person to the organizers team? That's great! Here's a list of some places that should be updated to include the new organizer.
 
-- [email aliases](https://github.com/nodeschool/email/blob/master/nodeschool.io/aliases.json) 
+- [email aliases](https://github.com/nodeschool/email/blob/master/nodeschool.io/aliases.json): This lets the new organizer receive emails sent to the official NodeSchoolYVR email. Listed organizers receive all emails sent to the email alias.
 - [chapter metadata](https://github.com/nodeschool/nodeschool.github.io/blob/source/chapters/vancouver.json)


### PR DESCRIPTION
New organizers should add themselves to the email alias and chapter metadata JSON files. This note shows where to find them.